### PR TITLE
Add `GBM_BACKENDS_PATH` env var

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -691,6 +691,9 @@ fn main() {
                 if dir == "dri" {
                     env::set_var("LIBGL_DRIVERS_PATH", dir_path)
                 }
+                if dir == "gbm" {
+                    env::set_var("GBM_BACKENDS_PATH", dir_path)
+                }
                 if dir.starts_with("spa-") {
                     env::set_var("SPA_PLUGIN_DIR", dir_path)
                 }


### PR DESCRIPTION
[The fucking variable is not documented](https://docs.mesa3d.org/envvars.html)

Found about it because I saw this [issue](https://github.com/probonopd/go-appimage/issues/337) at go-appimage 👀