### PR TITLE
set `FONTCONFIG_FILE` when host `/etc/fonts` is not present

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -850,7 +850,8 @@ fn main() {
                         match name.to_str().unwrap() {
                             "fonts" => {
                                 let fonts_conf = entry_path.join("fonts.conf");
-                                if fonts_conf.exists() {
+                                let sys_fonts_conf = PathBuf::from("/etc/fonts/fonts.conf");
+                                if fonts_conf.exists() && ! sys_fonts_conf.exists() {
                                     env::set_var("FONTCONFIG_FILE", fonts_conf)
                                 }
                             }


### PR DESCRIPTION
fixes https://github.com/pkgforge-dev/Zenity-GTK3-AppImage/issues/4

I have not been able to test this change because how do you make the CI release the binaries??? 😅