### PR TITLE
possible fix for weird bug

### DIFF
--- a/lib4bin
+++ b/lib4bin
@@ -843,7 +843,7 @@ if [[  ! -d "$WRAPPE_DIR" || "$WITH_PYTHON" == 1 ]]
                                                         lib_src_name="$(basename "$lib_src_pth")"
                                                         grep -qE '/lib32|/i386-linux-gnu|/arm-linux-gnu'<<<"$lib_src_dirname_pth" && \
                                                             lib_dir="lib32"||lib_dir="lib"
-                                                        lib_dst_dir_pth="${dst_dir_pth}/${lib_dir}$(sed \
+                                                        lib_dst_dir_pth="${dst_dir_pth}/${lib_dir}/$(sed \
                                                             "s|$dst_dir||;s|/shared||;s|^/usr||;s|^/opt||;s|^/lib64||;s|^/lib32||;s|^/lib||;s|^/.*-linux-gnu||"<<<"$lib_src_dirname_pth")"
                                                         [ -n "$lib_src_real_name" ] && \
                                                             lib_dst_pth="$lib_dst_dir_pth/$lib_src_real_name"||\


### PR DESCRIPTION
Got a report from a gentoo user that `lib4bin` makes a `shared/libproxy` instead of a `shared/lib/libproxy` directory. 

I think the issue is due to the lack of a slash when `lib_dst_dir_pth` is declared. but I am not sure, no idea how this has been working all this time before without issue. 