### PR TITLE
always include `/run/opengl-driver/share` in `XDG_DATA_DIRS`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -796,6 +796,7 @@ fn main() {
             if let Ok(dir) = share_dir.read_dir() {
                 add_to_env("XDG_DATA_DIRS", "/usr/local/share");
                 add_to_env("XDG_DATA_DIRS", "/usr/share");
+                add_to_env("XDG_DATA_DIRS", "/run/opengl-driver/share");
                 add_to_env("XDG_DATA_DIRS", format!("{}/.local/share", get_env_var("HOME")));
                 add_to_env("XDG_DATA_DIRS", &share_dir);
                 let xdg_data_dirs = &get_env_var("XDG_DATA_DIRS");


### PR DESCRIPTION
this locaiton is set by NixOS and it is where all icds are located, dispite being named `opengl-driver` the vulkan icds also live there. 

This allows apps to work on NixOS that use the proprietary nvidia driver out of the box without the user having to do anything.

Came as result of a report at Eden.

Not sure if you would like to check if the dir exists before being appended, anyways I suck with rust 😹


