### PR TITLE
always add the `C.utf8` locale

### DIFF
--- a/lib4bin
+++ b/lib4bin
@@ -1170,6 +1170,15 @@ if [[  ! -d "$WRAPPE_DIR" || "$WITH_PYTHON" == 1 ]]
                                                                                         hook_msg "copy gconv-modules file..."
                                                                                         try_cp "$sys_gconv_modules_file" "$dst_gconv_modules_file"
                                                                                 fi ;;
+                                                                            */libc*.so*)
+                                                                                sys_c_locale_dir="$(dirname "$lib_src_pth")/locale/C.utf8"
+                                                                                dst_c_locale_dir="$(dirname "$lib_dst_pth")/locale/C.utf8"
+                                                                                if [[ -d "$sys_c_locale_dir" &&  ! -d "$dst_c_locale_dir" ]]
+                                                                                    then
+                                                                                        hook_msg "copy glibc C.utf8 locale"
+                                                                                        try_mkdir "$dst_c_locale_dir"
+                                                                                        try_cp -T "$sys_c_locale_dir" "$dst_c_locale_dir"
+                                                                                fi ;;
                                                                         esac
                                                                 fi
                                                                 LIBRARIES["$lib_dst_pth"]=1


### PR DESCRIPTION
What I was doing [of falling back to C locale](https://github.com/pkgforge-dev/Anylinux-AppImages/blob/8a72ffb9d01c88ead9f19ce2b491667199156c28/useful-tools/lib/anylinux.c#L38-L49) when the app is not able to switch locale is very flawed.

Because I just ran into an app that crashes if the locale is not an UTF-8 locale. 

This means that instead we always have to guarantee that the C UTF-8 locale is always available, it is 350 KIB so there is no bloat argument here.

**Note this is only part of the puzzle**, for this to be complete sharun would need to check if the application will be able to switch to the configured host locale and **if not**, it would then need to set `LOCPATH` to `${SHARUN_DIR}/lib/locale` and set `LC_ALL=C.UTF-8`.

This will also remove the warnings that happen with GTK and Qt that they need an UTF-8 locale to work: 

<img width="533" height="61" alt="image" src="https://github.com/user-attachments/assets/fa39ecbd-662f-4415-b541-a844b57a5029" />
