### PR TITLE
add imagemagick hook (unable to complete)

### DIFF
--- a/lib4bin
+++ b/lib4bin
@@ -1172,6 +1172,19 @@ if [[  ! -d "$WRAPPE_DIR" || "$WITH_PYTHON" == 1 ]]
                                                                                                 break
                                                                                         fi
                                                                                 done ;;
+                                                                            */libMagick*.so*)
+                                                                                dst_magick_dir="$dst_dir/etc/ImageMagick"
+                                                                                if [[ ! -d "$dst_magick_dir" ]]
+                                                                                    then
+                                                                                        try_mkdir "$dst_magick_dir"
+                                                                                        hook_msg "copy ImageMagick config files..."
+                                                                                        for f in /usr/share/ImageMagick*/* /etc/ImageMagick*/* "$(dirname "$lib_src_pth")"/ImageMagick*/config*/*.xml
+                                                                                            do
+                                                                                                if [[ -f "$f" ]]
+                                                                                                    then try_cp "$f" "$dst_magick_dir"
+                                                                                                fi
+                                                                                        done
+                                                                                fi ;;
                                                                             */libgirepository-*.so*)
                                                                                 girepository="$(grep -o 'girepository-.*\.so'<<<"$lib_src_name"|sed "s|\.so$||")"
                                                                                 sys_girepository="${lib_src_dirname_pth}/$girepository"

--- a/lib4bin
+++ b/lib4bin
@@ -1173,15 +1173,16 @@ if [[  ! -d "$WRAPPE_DIR" || "$WITH_PYTHON" == 1 ]]
                                                                                         fi
                                                                                 done ;;
                                                                             */libMagick*.so*)
-                                                                                dst_magick_dir="$dst_dir/etc/ImageMagick"
-                                                                                if [[ ! -d "$dst_magick_dir" ]]
+                                                                                src_magick_config_dir="$(echo /etc/ImageMagick*)"
+                                                                                dst_magick_config_dir="$dst_dir/etc/$(basename "$src_magick_config_dir")"
+                                                                                if [[ -d "$src_magick_config_dir" ]] && [[ ! -d "$dst_magick_config_dir" ]]
                                                                                     then
-                                                                                        try_mkdir "$dst_magick_dir"
+                                                                                        try_mkdir "$dst_magick_config_dir"
                                                                                         hook_msg "copy ImageMagick config files..."
-                                                                                        for f in /usr/share/ImageMagick*/* /etc/ImageMagick*/* "$(dirname "$lib_src_pth")"/ImageMagick*/config*/*.xml
+                                                                                        for f in /usr/share/ImageMagick*/* "$src_magick_config_dir"/* "$(dirname "$lib_src_pth")"/ImageMagick*/config*/*.xml
                                                                                             do
                                                                                                 if [[ -f "$f" ]]
-                                                                                                    then try_cp "$f" "$dst_magick_dir"
+                                                                                                    then try_cp "$f" "$dst_magick_config_dir"
                                                                                                 fi
                                                                                         done
                                                                                 fi ;;


### PR DESCRIPTION
ImageMagick is complicated.

It has a ton of config files all over the place in `/usr/share/ImageMagick` `/usr/lib/ImageMagick` and `/etc/ImageMagick`

It turns out you can put all those files in and a single directory and set `MAGICK_CONFIGURE_PATH` to it, tested it working and all fine here. 

This hook does that operation. 

---

What is not complete is all the env variables that sharun would need to set, It is beyond my rust capabilities: 

* `MAGICK_HOME=$(SHARUN_DIR)` When imageMagick is compiled with a portable flag. We also need to set these others for when ImageMagick is not compiled portable:

* `MAGICK_CODER_FILTER_PATH=${SHARUN_DIR}/lib/ImageMagick*/modules*/filters`

* `MAGICK_CODER_MODULE_PATH=${SHARUN_DIR}/lib/ImageMagick*/modules*/coders`

* `MAGICK_CONFIGURE_PATH=${SHARUN_DIR}/etc/ImageMagick*`

[See what I'm doing in shell](https://github.com/pkgforge-dev/Anylinux-AppImages/blob/91aa9b3447ca775ab9a2ec4f11c8b171e854b7a3/useful-tools/quick-sharun.sh#L2080-L2105)

Yes I actuall went and read the ImageMagick documentation. [And was the first person to do so](https://github.com/ImageMagick/ImageMagick/pull/8561) xd