### PR TITLE
remove dependency to `/bin/sh` when using `AppRun` script

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -124,6 +124,26 @@ fn which(executable: &str) -> Option<PathBuf> {
     None
 }
 
+fn find_shell() -> Option<PathBuf> {
+    let candidates = [
+        PathBuf::from("/bin/sh"),
+        PathBuf::from("/bin/bash"),
+        PathBuf::from("/usr/bin/sh"),
+        PathBuf::from("/usr/bin/bash"),
+    ];
+    for candidate in candidates {
+        if is_exe(&candidate) {
+            return Some(candidate);
+        }
+    }
+    for name in ["sh", "bash"] {
+        if let Some(path) = which(name) {
+            return Some(path);
+        }
+    }
+    None
+}
+
 fn is_script(path: &PathBuf) -> Result<bool> {
     let mut file = File::open(path)?;
     let mut buffer = [0; 2];
@@ -564,6 +584,23 @@ fn main() {
             exit(1)
         }
     } else if bin_name == "AppRun" {
+        let apprun_wrapped = Path::new(&sharun_dir).join("AppRun.sh");
+        if apprun_wrapped.exists() {
+            let shell = find_shell().unwrap_or_else(|| {
+                eprintln!(
+                    "Failed to find a shell for {}",
+                    apprun_wrapped.display()
+                );
+                exit(1)
+            });
+
+            let err = Command::new(shell)
+                .arg(apprun_wrapped)
+                .args(exec_args)
+                .exec();
+            eprintln!("Failed to run AppRun.sh: {err}");
+            exit(1);
+        }
         let appname_file = &format!("{sharun_dir}/.app");
         let mut appname: String = "".into();
         if !Path::new(appname_file).exists() {


### PR DESCRIPTION
This guarantees that the application will run even if `/bin/sh` is not present on the host. 

* first checks for common shell locations in `/bin/sh`, `/bin/bash`, etc

* finally defaults to using `PATH` if all of those fail. 

**Note:** It is very important that sharun does not read its `.env` file when doing this, because otherwise the host shell can inherit env variables from the `.env` that break.

---

Tested it working: 

<img width="630" height="612" alt="image" src="https://github.com/user-attachments/assets/9e24c221-7797-4522-a40a-0ab660880624" />


---

This can be further extended, for example one can have an `AppRun.bash` and in that case `sharun` would look for a `bash` shell only, same with a `AppRun.py` where sharun would look for a `python` executable to run it and so on. 
