### PR TITLE
patch alsa config to also look into bundled config dir

### DIFF
--- a/lib4bin
+++ b/lib4bin
@@ -1034,6 +1034,7 @@ if [[  ! -d "$WRAPPE_DIR" || "$WITH_PYTHON" == 1 ]]
                                                                                         hook_msg "copy alsa config..."
                                                                                         try_mkdir "$dst_alsaconf_dir"
                                                                                         try_cp -T "$sys_alsaconf_dir" "$dst_alsaconf_dir"
+                                                                                        sed -i -e 's|"/etc/alsa/conf.d"|"/etc/alsa/conf.d"\n\t\t\t{ @func concat strings [ { @func getenv vars [ SHARUN_DIR ] default "" } "/share/alsa/alsa.conf.d" ] }|' "$dst_alsaconf_dir"/alsa.conf
                                                                                 fi ;;
                                                                             */libxkbcommon*.so*)
                                                                                 sys_xcb_dir="$(readlink -f /usr/share/X11/xkb)"

--- a/lib4bin
+++ b/lib4bin
@@ -1034,7 +1034,7 @@ if [[  ! -d "$WRAPPE_DIR" || "$WITH_PYTHON" == 1 ]]
                                                                                         hook_msg "copy alsa config..."
                                                                                         try_mkdir "$dst_alsaconf_dir"
                                                                                         try_cp -T "$sys_alsaconf_dir" "$dst_alsaconf_dir"
-                                                                                        sed -i -e 's|"/etc/alsa/conf.d"|"/etc/alsa/conf.d"\n\t\t\t{ @func concat strings [ { @func getenv vars [ SHARUN_DIR ] default "" } "/share/alsa/alsa.conf.d" ] }|' "$dst_alsaconf_dir"/alsa.conf
+                                                                                        [ -f "$dst_alsaconf_dir"/alsa.conf ] && sed -i -e 's|"/etc/alsa/conf.d"|"/etc/alsa/conf.d"\n\t\t\t{ @func concat strings [ { @func getenv vars [ SHARUN_DIR ] default "" } "/share/alsa/alsa.conf.d" ] }|' "$dst_alsaconf_dir"/alsa.conf
                                                                                 fi ;;
                                                                             */libxkbcommon*.so*)
                                                                                 sys_xcb_dir="$(readlink -f /usr/share/X11/xkb)"


### PR DESCRIPTION
Setting `ALSA_CONFIG_PATH` only changes the path to the config file, but the file is still hardcoded to look into `/etc/alsa` and a few other locations.

```
@hooks [
	{
		func load
		files [
			"/var/lib/alsa/conf.d"
			"/usr/etc/alsa/conf.d"
			"/etc/alsa/conf.d"
			"/etc/asound.conf|||/usr/etc/asound.conf"
			"~/.asoundrc"
			{
				@func concat
				strings [
					{
						@func getenv
						vars [
							XDG_CONFIG_HOME
						]
						default "~/.config"
					}
					"/alsa/asoundrc"
				]
			}
		]
		errors false
	}
]

```

So when none of those files are present, alsa crashes lol

This patch makes alsa look into the bundled `$SHARUN_DIR/share/alsa/alsa.conf.d` to avoid such crashes. 