### PR TITLE
add `/etc` to `XDG_DATA_DIRS`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -860,6 +860,7 @@ fn main() {
         let share_dir = PathBuf::from(format!("{sharun_dir}/share"));
         if share_dir.exists() {
             if let Ok(dir) = share_dir.read_dir() {
+                add_to_env("XDG_DATA_DIRS", "/etc");
                 add_to_env("XDG_DATA_DIRS", "/run/current-system/sw/share");
                 add_to_env("XDG_DATA_DIRS", "/run/opengl-driver/share");
                 add_to_env("XDG_DATA_DIRS", "/usr/share");


### PR DESCRIPTION
Yeah, someone had the nvidia driver there 💀

Apparently the `.run` nvidia installer puts the driver there by default.